### PR TITLE
Clarify `extract_test_dirs`' name

### DIFF
--- a/analyses/1.Transfer_Sepsis_to_TB.ipynb
+++ b/analyses/1.Transfer_Sepsis_to_TB.ipynb
@@ -109,7 +109,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Split train and test data\n",
+    "# Split data into tuberculosis and non-tuberculosis\n",
     "\n",
     "data_dirs = util.get_data_dirs('../data')                                                      \n",
     "non_tb_dirs, tb_dirs = util.extract_dirs_with_label(data_dirs, 'tb', sample_to_label)                                               \n",

--- a/analyses/1.Transfer_Sepsis_to_TB.ipynb
+++ b/analyses/1.Transfer_Sepsis_to_TB.ipynb
@@ -112,9 +112,9 @@
     "# Split train and test data\n",
     "\n",
     "data_dirs = util.get_data_dirs('../data')                                                      \n",
-    "train_dirs, test_dirs = util.extract_test_dirs(data_dirs, 'tb', sample_to_label)                                               \n",
+    "non_tb_dirs, tb_dirs = util.extract_dirs_with_label(data_dirs, 'tb', sample_to_label)                                               \n",
     "\n",
-    "train_dirs, tune_dirs = util.train_tune_split(train_dirs, 2)"
+    "train_dirs, tune_dirs = util.train_tune_split(non_tb_dirs, 2)"
    ]
   },
   {
@@ -231,7 +231,7 @@
    "outputs": [],
    "source": [
     "# Load tuberculosis data\n",
-    "tb_dataset = dataset.ExpressionDataset(test_dirs, sample_to_label, label_to_encoding, gene_file)\n",
+    "tb_dataset = dataset.ExpressionDataset(tb_dirs, sample_to_label, label_to_encoding, gene_file)\n",
     "tb_loader = torch.utils.data.DataLoader(tb_dataset, batch_size=16, num_workers=4, pin_memory=True)"
    ]
   },

--- a/whistl/util.py
+++ b/whistl/util.py
@@ -62,7 +62,7 @@ def get_data_dirs(data_root):
     return data_dirs
 
 
-def extract_test_dirs(data_dirs, disease_label, sample_to_label):
+def extract_dirs_with_label(data_dirs, disease_label, sample_to_label):
     ''' Split the list of directories passed in into those that contain samples with a given
     disease, and those that don't
 
@@ -78,13 +78,13 @@ def extract_test_dirs(data_dirs, disease_label, sample_to_label):
 
     Returns
     -------
-    train_dirs: list of str or Path
+    dirs_without_label: list of str or Path
         The directories from data_dirs not containing any samples corresponding to disease_label
-    test_dirs: list of str or Path
+    dirs_with_label: list of str or Path
         The directories from data_dirs that do contain samples with the provided disease
     '''
-    train_dirs = []
-    test_dirs = []
+    dirs_without_label = []
+    dirs_with_label = []
 
     for data_dir in data_dirs:
         study = os.path.basename(os.path.normpath(data_dir))
@@ -100,13 +100,13 @@ def extract_test_dirs(data_dirs, disease_label, sample_to_label):
         for sample_id in sample_ids:
             if sample_id in sample_to_label:
                 if sample_to_label[sample_id] == disease_label:
-                    test_dirs.append(data_dir)
+                    dirs_with_label.append(data_dir)
                     break
         else:
-            # If the the dir isn't added to test_dirs, add to train_dirs
-            train_dirs.append(data_dir)
+            # If the the dir isn't added to dirs_with_label, add to dirs_without_label
+            dirs_without_label.append(data_dir)
 
-    return train_dirs, test_dirs
+    return dirs_without_label, dirs_with_label
 
 
 def add_genes_to_results(results, gene_file):


### PR DESCRIPTION
This PR renames the function `extract_test_dirs` to `extract_dirs_with_label` to reflect what the function does instead of what it was used for