### PR TITLE
Compendium pipeline

### DIFF
--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -1,0 +1,44 @@
+'''A set of tests for functions in datasets.py. Each function is named according to the function
+that it tests in datasets.py.'''
+
+import json
+import os
+import sys
+import unittest
+
+import pytest
+
+whistl_path = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(whistl_path + '/../whistl')
+import datasets
+
+
+example_metadata = json.loads('''{"experiments": {"GSE14844": {"sample_accession_codes": [
+                        "GSM371398",
+                        "GSM371375"]},
+                    "GSE-ABC": {"sample_accession_codes": [
+                        "GSMA",
+                        "GSMB",
+                        "GSMC"]}}}''')
+sample_to_study_example = {'GSM371398': 'GSE14844', 'GSM371375': 'GSE14844',
+                           'GSMA': 'GSE-ABC', 'GSMB': 'GSE-ABC', 'GSMC': 'GSE-ABC'}
+study_to_sample_example = {'GSE14844': ['GSM371398', 'GSM371375'],
+                           'GSE-ABC': ['GSMA', 'GSMB', 'GSMC']}
+
+
+@pytest.mark.parametrize('metadata,correct_dict',
+                         [(example_metadata, sample_to_study_example),
+                          ])
+def test_create_sample_to_study_mapping(metadata, correct_dict):
+    pred_dict = datasets.create_sample_to_study_mapping(metadata)
+    tc = unittest.TestCase()
+    tc.assertDictEqual(correct_dict, pred_dict)
+
+
+@pytest.mark.parametrize('metadata,correct_dict',
+                         [(example_metadata, study_to_sample_example),
+                          ])
+def test_create_study_to_sample_mapping(metadata, correct_dict):
+    pred_dict = datasets.create_study_to_sample_mapping(metadata)
+    tc = unittest.TestCase()
+    tc.assertDictEqual(correct_dict, pred_dict)

--- a/whistl/0.create_compendium_subset.py
+++ b/whistl/0.create_compendium_subset.py
@@ -1,0 +1,41 @@
+'''Save the subset of hte compendium that has already been labeled to allow faster loading'''
+import argparse
+
+import pandas as pd
+
+import utils
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser('This script saves the subset of the compendium that has '
+                                     'already been labeled to allow faster loading and training')
+    parser.add_argument('compendium', help='The refine.bio file containing the gene expression '
+                                            'data to subset')
+    parser.add_argument('map_file', help='The file produced by label_samples with sample labels.')
+    parser.add_argument('out_path', help='The location to write the resulting tsv to')
+    args = parser.parse_args()
+
+    # Next ~20 lines graciously lifted from comendium_eda.ipynb
+    sample_to_label = utils.parse_map_file(args.map_file)
+    sample_ids = sample_to_label.keys()
+
+    compendium_path = args.compendium
+
+    # Not all labeled samples show up in the compendium, which causes pandas to panic. To fix this
+    # we have to take the intersection of the accessions in sample_ids and the accessions in the
+    # compendium
+    header_ids = None
+    with open(compendium_path) as in_file:
+        header = in_file.readline()
+        header_ids = header.split('\t')
+
+    valid_sample_ids = [id_ for id_ in sample_ids if id_ in header_ids]
+
+    # This is hacky, but the devs explicitly want to index_col to pull from only cols in usecols so
+    # there isn't a better way to do it without manually changing the original file
+    # Further reading https://github.com/pandas-dev/pandas/issues/9098 and
+    # https://github.com/pandas-dev/pandas/issues/2654
+    valid_sample_ids.append('Unnamed: 0')
+
+    compendium_df = pd.read_csv(compendium_path, sep='\t', index_col=0, usecols=valid_sample_ids, nrows=5)
+
+    compendium_df.to_csv(args.out_path, sep='\t')

--- a/whistl/0.create_compendium_subset.py
+++ b/whistl/0.create_compendium_subset.py
@@ -1,4 +1,4 @@
-'''Save the subset of hte compendium that has already been labeled to allow faster loading'''
+'''Save the subset of the compendium that has already been labeled to allow faster loading'''
 import argparse
 
 import pandas as pd
@@ -9,12 +9,12 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser('This script saves the subset of the compendium that has '
                                      'already been labeled to allow faster loading and training')
     parser.add_argument('compendium', help='The refine.bio file containing the gene expression '
-                                            'data to subset')
+                                           'data to subset')
     parser.add_argument('map_file', help='The file produced by label_samples with sample labels.')
     parser.add_argument('out_path', help='The location to write the resulting tsv to')
     args = parser.parse_args()
 
-    # Next ~20 lines graciously lifted from comendium_eda.ipynb
+    # Next ~20 lines graciously lifted from notebooks/eda/compendium_eda.ipynb
     sample_to_label = utils.parse_map_file(args.map_file)
     sample_ids = sample_to_label.keys()
 

--- a/whistl/0.create_compendium_subset.py
+++ b/whistl/0.create_compendium_subset.py
@@ -36,6 +36,6 @@ if __name__ == '__main__':
     # https://github.com/pandas-dev/pandas/issues/2654
     valid_sample_ids.append('Unnamed: 0')
 
-    compendium_df = pd.read_csv(compendium_path, sep='\t', index_col=0, usecols=valid_sample_ids, nrows=5)
+    compendium_df = pd.read_csv(compendium_path, sep='\t', index_col=0, usecols=valid_sample_ids)
 
     compendium_df.to_csv(args.out_path, sep='\t')

--- a/whistl/label_samples.py
+++ b/whistl/label_samples.py
@@ -29,9 +29,6 @@ def unlabel_samples(labeled_samples, set_of_labeled_samples):
         if choice == 'no':
             return labeled_samples, set_of_labeled_samples
         elif choice == 'yes':
-            print('Current sample labels:')
-            print(labeled_samples)
-
             sample = input('Sample to remove: ').strip().upper()
             if sample in set_of_labeled_samples:
                 set_of_labeled_samples.remove(sample)
@@ -284,8 +281,8 @@ if __name__ == '__main__':
             else:
                 labeled_samples[sample_label] = [sample]
             set_of_labeled_samples.add(sample)
-
-        print('All samples are labeled!')
+        else:
+            print('All samples are labeled!')
 
         # If the user makes a mistake, give them the option to unlabel samples
         labeled_samples, set_of_labeled_samples = unlabel_samples(labeled_samples,

--- a/whistl/utils.py
+++ b/whistl/utils.py
@@ -35,7 +35,7 @@ def count_items_in_dataloader(dataloader):
 
 
 def get_gene_count(gene_file):
-    '''
+    '''Count the number of genes in a file produced by microarray_rnaseq_gene_intersection.py
 
     Arguments
     ---------


### PR DESCRIPTION
Previously all the data I had been using was downloaded manually from the refine.bio GUI. Now that there is a human compendium, samples can be pulled from that instead. This PR contains the infrastructure to make that happen

Changes:
- created the `CompendiumDataset` class, and utility functions used to initialize it
- Wrote the script `0.create_compendium_subset.py` to create a tsv containing the subset of the compendium samples that have already been labled. This is useful because the whole thing is 120GB and doesn't fit in memory
- Created the `test_dataset.py` file and added some test cases to it
- Made minor quality of life and documentation changes in `utils.py` and `label_samples.py`